### PR TITLE
WNYC-279 WNYC Theme on Persistent Player

### DIFF
--- a/src/components/PersistentPlayer.vue
+++ b/src/components/PersistentPlayer.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="persistent-player u-color-group-dark">
+  <div
+    class="persistent-player u-color-group-dark"
+    :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-ready': neverPlayed}"
+  >
     <div class="player-controls">
       <TrackInfo
         :livestream="livestream"
@@ -232,9 +235,9 @@ export default {
       this.audio.currentTime = 0
     },
     togglePlay () {
-      this.neverPlayed = false;
       this.playing = !this.playing
       this.$emit('togglePlay')
+      this.neverPlayed = false
     },
     update () {
       this.currentSeconds = this.audio.currentTime

--- a/src/components/PersistentPlayer.vue
+++ b/src/components/PersistentPlayer.vue
@@ -303,10 +303,6 @@ export default {
     align-items: center;
   }
 
-    .player-controls .player-cta-play-button {
-
-    }
-
     .player-controls svg {
       fill: RGB(var(--color-text));
     }

--- a/src/components/PersistentPlayer.vue
+++ b/src/components/PersistentPlayer.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="persistent-player u-color-group-dark"
-    :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-ready': neverPlayed}"
+    :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-initial': !hasPlayed}"
   >
     <div class="player-controls">
       <TrackInfo
@@ -17,31 +17,42 @@
         :duration-seconds="durationSeconds"
         @seek="seek"
       />
-      <VolumeControl v-model.number="volume" />
-      <a
-        v-if="showSkip && !livestream"
-        class="player-back-15-icon"
-        aria-label="go back 15 seconds"
-        @click="goBack15"
-      >
-        <back15 />
-      </a>
-      <a
-        class="play-button"
-        :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-ready': neverPlayed}"
-        :aria-label="playing ? 'pause' : 'play'"
-        @click="togglePlay"
-      >
-        <play-icon />
-      </a>
-      <a
-        v-if="showSkip && !livestream"
-        class="player-ahead-15-icon"
-        aria-label="go ahead 15 seconds"
-        @click="goAhead15"
-      >
-        <ahead15 />
-      </a>
+      <template v-if="shouldShowCta && !hasPlayed">
+        <button
+          class="button player-cta-play-button"
+          @click="togglePlay"
+        >
+          <play-simple class="button-icon" />
+          <span class="button-text">Listen Live</span>
+        </button>
+      </template>
+      <template v-else>
+        <VolumeControl v-model.number="volume" />
+        <a
+          v-if="showSkip && !livestream"
+          class="player-back-15-icon"
+          aria-label="go back 15 seconds"
+          @click="goBack15"
+        >
+          <back15 />
+        </a>
+        <a
+          class="play-button"
+          :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-initial': !hasPlayed}"
+          :aria-label="playing ? 'pause' : 'play'"
+          @click="togglePlay"
+        >
+          <play-icon />
+        </a>
+        <a
+          v-if="showSkip && !livestream"
+          class="player-ahead-15-icon"
+          aria-label="go ahead 15 seconds"
+          @click="goAhead15"
+        >
+          <ahead15 />
+        </a>
+      </template>
       <a
         v-if="showDownload && !livestream"
         tabindex="0"
@@ -65,6 +76,7 @@
 
 <script>
 import PlayIcon from './icons/PlayIcon'
+import PlaySimple from './icons/PlaySimple'
 import Back15 from './icons/Back15'
 import Ahead15 from './icons/Ahead15'
 import DownloadIcon from './icons/DownloadIcon'
@@ -75,6 +87,7 @@ export default {
   name: 'PersistentPlayer',
   components: {
     PlayIcon,
+    PlaySimple,
     Back15,
     Ahead15,
     VolumeControl,
@@ -107,6 +120,10 @@ export default {
       default: false
     },
     playing: {
+      type: Boolean,
+      default: false
+    },
+    shouldShowCta: {
       type: Boolean,
       default: false
     },
@@ -147,7 +164,7 @@ export default {
       buffered: 0,
       innerLoop: false,
       loaded: false,
-      neverPlayed: true,
+      hasPlayed: false,
       previousVolume: 35,
       showVolume: false,
       volume: 100
@@ -237,7 +254,7 @@ export default {
     togglePlay () {
       this.playing = !this.playing
       this.$emit('togglePlay')
-      this.neverPlayed = false
+      this.hasPlayed = true
     },
     update () {
       this.currentSeconds = this.audio.currentTime
@@ -286,8 +303,17 @@ export default {
     align-items: center;
   }
 
+    .player-controls .player-cta-play-button {
+
+    }
+
     .player-controls svg {
       fill: RGB(var(--color-text));
+    }
+
+    .player-controls .player-cta-play-button svg path {
+      fill: RGB(var(--color-text));
+
     }
 
     .player-controls .play-button {

--- a/src/components/PersistentPlayer.vue
+++ b/src/components/PersistentPlayer.vue
@@ -25,7 +25,7 @@
       </a>
       <a
         class="play-button"
-        :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded}"
+        :class="{'is-playing': playing, 'is-paused': !playing, 'is-loading': !loaded, 'is-ready': neverPlayed}"
         :aria-label="playing ? 'pause' : 'play'"
         @click="togglePlay"
       >
@@ -144,6 +144,7 @@ export default {
       buffered: 0,
       innerLoop: false,
       loaded: false,
+      neverPlayed: true,
       previousVolume: 35,
       showVolume: false,
       volume: 100
@@ -231,6 +232,7 @@ export default {
       this.audio.currentTime = 0
     },
     togglePlay () {
+      this.neverPlayed = false;
       this.playing = !this.playing
       this.$emit('togglePlay')
     },

--- a/src/components/TrackInfo.vue
+++ b/src/components/TrackInfo.vue
@@ -145,13 +145,14 @@ export default {
 }
 
   .track-info-image {
+    --track-info-image-size: 80px;
     display: none;
     @media all and (min-width: $medium) {
       display: inline-block;
-      width: 80px;
-      max-width: 80px;
-      height: 80px;
-      flex: 1 0 80px;
+      width: var(--track-info-image-size);
+      max-width: var(--track-info-image-size);
+      height: var(--track-info-image-size);;
+      flex: 1 0 var( --track-info-image-size);
       margin-right: 16px;
     }
   }
@@ -191,6 +192,12 @@ export default {
         height: 8px;
         width: 8px;
       }
+
+    .track-info-livestream-station {
+      font-family: var(--font-family-body);
+      font-size: var(--font-size-2);
+      font-weight: 700;
+    }
 
   .track-info-title {
     font-family: var(--font-family-subheader);

--- a/src/styles/themes/wnyc/_theme.colors.scss
+++ b/src/styles/themes/wnyc/_theme.colors.scss
@@ -6,11 +6,11 @@
   /* Theme Color Palette */
 
   /* Neutrals */
-  --color-black:      #{hex2rgb(#000000)};
-  --color-dark-gray:  #{hex2rgb(#333333)};
-  --color-gray:       #{hex2rgb(#ae969a)};
-  --color-light-gray: #{hex2rgb(#f3f3f3)};
-  --color-white:      #{hex2rgb(#ffffff)};
+  --color-black:        #{hex2rgb(#000000)};
+  --color-dark-gray:    #{hex2rgb(#333333)};
+  --color-gray:         #{hex2rgb(#ae969a)};
+  --color-light-gray:   #{hex2rgb(#f3f3f3)};
+  --color-white:        #{hex2rgb(#ffffff)};
 
   /* Forms */
   --color-valid:              #{hex2rgb(#089E00)};
@@ -22,6 +22,8 @@
   --color-concrete:           #{hex2rgb(#E0E2E3)};
   --color-red:                #{hex2rgb(#de1e3d)};
   --color-dark-red:           #{hex2rgb(#6a1017)};
+  --color-almost-black:       #{hex2rgb(#101012)};
+
 }
 
 @mixin color-group-light {

--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -360,9 +360,16 @@ h1, h2, h3, h4, h5 {
 
 // persistent player
 .persistent-player {
+  --color-text: var(--color-white);
+  --color-text-inverse:  var(--color-black);
   background-color: RGB(var(--color-almost-black));
   height: 112px;
 }
+
+
+.persistent-player .play-button.is-ready.is-loading {
+  display: none;
+} 
 
 .persistent-player .play-button.is-ready {
   background: RGB(var(--color-red));
@@ -370,14 +377,33 @@ h1, h2, h3, h4, h5 {
   border-radius: 30px;
   width: 209px;
   height: 47px;
+  transition: none;
+  justify-content: flex-start;
+}
+
+.persistent-player .play-button.is-ready:hover {
+  transition: none;
 }
 
 .persistent-player .play-button.is-ready svg {
-  height: 150%;
+  transition: none;
+  height: 47px;
+  width: 28px;
+  overflow: hidden;
+  margin: 0 4px 0 27px;
 }
 
 .persistent-player .play-button.is-ready .outer-circle {
   display: none;
+}
+
+.persistent-player.is-ready.is-paused .volume-control {
+  display: none;
+}
+
+.persistent-player .play-button.is-ready .play {
+  transform-origin: center 32px;
+  transform: scale(1.5);
 }
 
 .persistent-player .play-button.is-ready:after {
@@ -388,6 +414,7 @@ h1, h2, h3, h4, h5 {
   font-weight: bold;
   font-size: var(--font-size-7);
   line-height: 47px;
+  letter-spacing: 0.09em;
 }
 
 .track-info-livestream-indicator {

--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -372,9 +372,15 @@ h1, h2, h3, h4, h5 {
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
   border-radius: 30px;
   height: 47px;
-  transition: none;
+  margin-right: 24px;
   justify-content: flex-start;
+  transition: all 0.1s ease-in-out;
 }
+
+  .persistent-player .player-cta-play-button:hover {
+    transform: translateY(-4px);
+    box-shadow: 0px 8px 12px rgba(0, 0, 0, .15);
+  }
 
   .persistent-player .player-cta-play-button .button-text {
     font-family: var(--font-family-body);

--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -366,56 +366,25 @@ h1, h2, h3, h4, h5 {
   height: 112px;
 }
 
-
-.persistent-player .play-button.is-ready.is-loading {
-  display: none;
-} 
-
-.persistent-player .play-button.is-ready {
+.persistent-player .player-cta-play-button {
+  color: RGB(var(--color-text));
   background: RGB(var(--color-red));
   box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
   border-radius: 30px;
-  width: 209px;
   height: 47px;
   transition: none;
   justify-content: flex-start;
 }
 
-.persistent-player .play-button.is-ready:hover {
-  transition: none;
-}
-
-.persistent-player .play-button.is-ready svg {
-  transition: none;
-  height: 47px;
-  width: 28px;
-  overflow: hidden;
-  margin: 0 4px 0 27px;
-}
-
-.persistent-player .play-button.is-ready .outer-circle {
-  display: none;
-}
-
-.persistent-player.is-ready.is-paused .volume-control {
-  display: none;
-}
-
-.persistent-player .play-button.is-ready .play {
-  transform-origin: center 32px;
-  transform: scale(1.5);
-}
-
-.persistent-player .play-button.is-ready:after {
-  content: "Listen Live";
-  font-family: var(--font-family-body);
-  text-transform: uppercase;
-  font-style: normal;
-  font-weight: bold;
-  font-size: var(--font-size-7);
-  line-height: 47px;
-  letter-spacing: 0.09em;
-}
+  .persistent-player .player-cta-play-button .button-text {
+    font-family: var(--font-family-body);
+    text-transform: uppercase;
+    font-style: normal;
+    font-weight: bold;
+    font-size: var(--font-size-7);
+    line-height: 47px;
+    letter-spacing: 0.09em;
+  }
 
 .track-info-livestream-indicator {
   background: transparent;

--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -17,6 +17,14 @@ a {
   border-bottom: solid 2px RGB(var(--color-white));
 }
 
+h1, h2, h3, h4, h5 {
+  // Use lining figures instead of text figures for headers
+  // https://www.codesmite.com/article/fixing-raleway-and-similar-fonts-numerals
+  -webkit-font-feature-settings: "lnum";
+  -moz-font-feature-settings: "lnum";
+  font-feature-settings: "lnum";
+}
+
 .dots {
   opacity: .5;
   background-image: radial-gradient(RGB(var(--color-white), .6) 2px, transparent 2px), radial-gradient(RGB(var(--color-white), .6) 2px, transparent 2px);
@@ -351,16 +359,70 @@ a {
 }
 
 // persistent player
-.nypr-o-audio-player {
-  grid-template-columns: 75% 25%;
-  grid-template-rows: auto;
+.persistent-player {
+  background-color: RGB(var(--color-almost-black));
+  height: 112px;
 }
 
-.nypr-o-audio-player,
-.nypr-o-audio-player-controls,
-.nypr-o-audio-player-play-button,
-.nypr-o-audio-player .button:active {
-  background-color: RGB(var(--color-dark-blue));
+.persistent-player .play-button.is-ready {
+  background: RGB(var(--color-red));
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.15);
+  border-radius: 30px;
+  width: 209px;
+  height: 47px;
+}
+
+.persistent-player .play-button.is-ready svg {
+  height: 150%;
+}
+
+.persistent-player .play-button.is-ready .outer-circle {
+  display: none;
+}
+
+.persistent-player .play-button.is-ready:after {
+  content: "Listen Live";
+  font-family: var(--font-family-body);
+  text-transform: uppercase;
+  font-style: normal;
+  font-weight: bold;
+  font-size: var(--font-size-7);
+  line-height: 47px;
+}
+
+.track-info-livestream-indicator {
+  background: transparent;
+  color: RGB(var(--color-text));
+}
+
+  .track-info-livestream-indicator-text {
+    margin-right: 2px;
+  }
+
+  .track-info-livestream-station {
+      // Use lining figures instead of text figures
+      // https://www.codesmite.com/article/fixing-raleway-and-similar-fonts-numerals
+      -webkit-font-feature-settings: "lnum";
+      -moz-font-feature-settings: "lnum";
+      font-feature-settings: "lnum";
+  }
+
+.track-info-image {
+  --track-info-image-size: 96px;
+}
+
+.track-info-title {
+  font-family: var(--font-family-body);
+
+}
+  .track-info-title h2 {
+    line-height: 1.25;
+  }
+
+.track-info-title-link,
+.track-info-description-link {
+  text-decoration: none;
+  border: none;
 }
 
 // stream switcher

--- a/stories/90-Components/Organisms/PersistentPlayer.stories.js
+++ b/stories/90-Components/Organisms/PersistentPlayer.stories.js
@@ -50,6 +50,23 @@ export const Livestream = () => ({
   `
 })
 
+export const LivestreamWithCta = () => ({
+  components: { PersistentPlayer },
+  template: `
+    <persistent-player
+      livestream
+      shouldShowCta
+      station="WNYC 93.9 FM"
+      image="images/Placeholder-Image-1_1.png"
+      title="The Takeaway"
+      title-link="http://www.google.com"
+      description="This week, people in Tulsa filed a lawsuit demanding reparations for victims and descendants of the Tulsa Race Massacre."
+      description-link="http://www.bing.com"
+      file="http://www.hochmuth.com/mp3/Haydn_Cello_Concerto_D-1.mp3"
+    />
+  `
+})
+
 export const LivestreamWithoutTitle = () => ({
   components: { PersistentPlayer },
   template: `


### PR DESCRIPTION
- style the player with to match the WNYC theme
- add a `shouldShowCta` flag that shows a CTA play button ("Listen Live") instead of player controls until the player has been played
- the button has a hardcoded "Listen Live" label for now but could be expanded to support a custom label in the future, i think consistent labeling across our sites is fine as a base assumption for now though...