### PR TITLE
Add link to image, update link styles

### DIFF
--- a/src/components/VCard.vue
+++ b/src/components/VCard.vue
@@ -4,12 +4,16 @@
       v-if="titleLink"
       class="card-image-link"
       :href="titleLink"
+      aria-hidden="true"
+      role="presentation"
+      tabindex="-1"
     >
       <img
         v-if="image"
         class="card-image"
         :src="image"
-        alt="alt"
+        :alt="title || alt"
+        role="presentation"
       >
     </a>
     <span
@@ -20,7 +24,8 @@
         v-if="image"
         class="card-image"
         :src="image"
-        alt="alt"
+        alt=""
+        role="presentation"
       >
     </span>
     <div
@@ -57,10 +62,6 @@
 export default {
   props: {
     image: {
-      type: String,
-      default: null
-    },
-    alt: {
       type: String,
       default: null
     },

--- a/src/components/VCard.vue
+++ b/src/components/VCard.vue
@@ -1,11 +1,28 @@
 <template>
   <div class="card">
-    <img
-      v-if="image"
-      class="card-image"
-      :src="image"
-      alt="alt"
+    <a
+      v-if="titleLink"
+      class="card-image-link"
+      :href="titleLink"
     >
+      <img
+        v-if="image"
+        class="card-image"
+        :src="image"
+        alt="alt"
+      >
+    </a>
+    <span
+      v-else
+      class="card-image-wrapper"
+    >
+      <img
+        v-if="image"
+        class="card-image"
+        :src="image"
+        alt="alt"
+      >
+    </span>
     <div
       v-if="hasDetails"
       class="card-details"
@@ -15,11 +32,15 @@
         class="card-title"
       >
         <a
+          v-if="titleLink"
           class="card-title-link"
           :href="titleLink"
         >
           {{ title }}
         </a>
+        <template v-else>
+          {{ title }}
+        </template>
       </div>
       <div
         v-if="subtitle"
@@ -96,6 +117,17 @@ export default {
   .card-title {
     font-family: var(--font-family-header);
     font-size: var(--font-size-7);
+  }
+
+  .card-title-link {
+    color: RGB(var(--color-text));
+    text-decoration: none;
+  }
+
+  .card-title-link:hover {
+    color: RGB(var(--color-text));
+    opacity: var(--opacity-link-hover);
+    text-decoration: none;
   }
 
   .card-subtitle {

--- a/src/components/VPerson.vue
+++ b/src/components/VPerson.vue
@@ -2,7 +2,6 @@
   <v-card
     class="person-card"
     :image="person.image"
-    alt=""
     :title="person.name"
     :title-link="person.nameLink"
     :subtitle="person.role"

--- a/src/tests/VCard.test.js
+++ b/src/tests/VCard.test.js
@@ -9,18 +9,20 @@ expect.extend(toHaveNoViolations)
 describe('VCard', () => {
   test('it renders props', () => {
     const image = 'http://placehold.it/175x175'
-    const alt = 'Title'
     const title = 'Title'
     const titleLink = 'https://example.com'
     const subtitle = 'Subtitle'
     const wrapper = mount(VCard, {
-      propsData: { image, alt, title, titleLink, subtitle }
+      propsData: { image, title, titleLink, subtitle }
     })
     // check if prop works and was rendered correctly
     const img = wrapper.find('.card-image')
+    const imgLinkTag = wrapper.find('.card-image-link')
     const titleLinkTag = wrapper.find('.card-title-link')
     const subtitleTag = wrapper.find('.card-subtitle')
     expect(img.attributes('src')).toBe(image)
+    expect(img.attributes('alt')).toBe(title)
+    expect(imgLinkTag.attributes('href')).toBe(titleLink)
     expect(titleLinkTag.text()).toContain(title)
     expect(titleLinkTag.attributes('href')).toBe(titleLink)
     expect(subtitleTag.text()).toContain(subtitle)
@@ -28,11 +30,10 @@ describe('VCard', () => {
 
   test('it renders without a link', () => {
     const image = 'http://placehold.it/175x175'
-    const alt = 'Title'
     const title = 'Title'
     const subtitle = 'Subtitle'
     const wrapper = mount(VCard, {
-      propsData: { image, alt, title, subtitle }
+      propsData: { image, title, subtitle }
     })
     // check if prop works and was rendered correctly
     const img = wrapper.find('.card-image')
@@ -40,6 +41,7 @@ describe('VCard', () => {
     const subtitleTag = wrapper.find('.card-subtitle')
     expect(wrapper.find('.card-title-link').exists()).toBe(false)
     expect(img.attributes('src')).toBe(image)
+    expect(img.attributes('alt')).toBe('')
     expect(titleTag.text()).toContain(title)
     expect(subtitleTag.text()).toContain(subtitle)
   })

--- a/src/tests/VCard.test.js
+++ b/src/tests/VCard.test.js
@@ -26,6 +26,42 @@ describe('VCard', () => {
     expect(subtitleTag.text()).toContain(subtitle)
   })
 
+  test('it renders without a link', () => {
+    const image = 'http://placehold.it/175x175'
+    const alt = 'Title'
+    const title = 'Title'
+    const subtitle = 'Subtitle'
+    const wrapper = mount(VCard, {
+      propsData: { image, alt, title, subtitle }
+    })
+    // check if prop works and was rendered correctly
+    const img = wrapper.find('.card-image')
+    const titleTag = wrapper.find('.card-title')
+    const subtitleTag = wrapper.find('.card-subtitle')
+    expect(wrapper.find('.card-title-link').exists()).toBe(false)
+    expect(img.attributes('src')).toBe(image)
+    expect(titleTag.text()).toContain(title)
+    expect(subtitleTag.text()).toContain(subtitle)
+  })
+
+  test('it renders without an image', () => {
+    const title = 'Title'
+    const titleLink = 'https://example.com'
+    const subtitle = 'Subtitle'
+    const wrapper = mount(VCard, {
+      propsData: { title, titleLink, subtitle }
+    })
+    // check if prop works and was rendered correctly
+    const titleTag = wrapper.find('.card-title')
+    const titleLinkTag = wrapper.find('.card-title-link')
+    const subtitleTag = wrapper.find('.card-subtitle')
+    expect(wrapper.find('.card-image').exists()).toBe(false)
+    expect(titleTag.text()).toContain(title)
+    expect(titleLinkTag.text()).toContain(title)
+    expect(titleLinkTag.attributes('href')).toBe(titleLink)
+    expect(subtitleTag.text()).toContain(subtitle)
+  })
+
   test('it passes basic accessibility tests', async () => {
     const image = 'http://placehold.it/175x175'
     const alt = 'Title'

--- a/stories/90-Components/Molecules/Person.stories.mdx
+++ b/stories/90-Components/Molecules/Person.stories.mdx
@@ -24,3 +24,26 @@ import VPerson from '../../../src/components/VPerson'
         }}
     </Story>
 </Canvas>
+
+<Canvas>
+    <Story name="Person with Link">
+        {{
+            components: { VPerson },
+            data() {
+                return {
+                    person: {
+                        image: 'http://placehold.it/200x200',
+                        name: 'Title',
+                        nameLink: 'http://example.com',
+                        role: 'Subtitle',
+                    }
+                }
+            },
+            template: `
+<v-person
+    :person="person"
+/>
+`
+        }}
+    </Story>
+</Canvas>


### PR DESCRIPTION
- Updated the link styles and made the image a link.
- Add some tests and another story
- Uses semantically questionable attributes to improve the screen reader UX, by hiding duplicated image and title links. This will be more important when we're using long lists of cards. I've seen conflicting info on whether or not this is a good idea or even works. Hard to say for sure without actually testing in NVDA, Narrator, Voiceover... 
  - An alternative here is to leave of the link tag and semantics out of markup altogether and just make the image part javascript clickable/tappable but not focusable otherwise. 
  - The "recommended" solution is to keep the img and text in the same `a` tag but the css to make this work and keep the layout we want seems impractical
  - Just letting there be duplicate links is also an option, not the greatest experience, but might be better than going with something hacky that could produce weird results in some cases