### PR TITLE
Person Updates

### DIFF
--- a/src/components/VCard.vue
+++ b/src/components/VCard.vue
@@ -1,21 +1,35 @@
 <template>
   <div class="card">
-    <a
-      v-if="titleLink"
-      class="card-image-link"
-      :href="titleLink"
-      aria-hidden="true"
-      role="presentation"
-      tabindex="-1"
-    >
-      <img
-        v-if="image"
-        class="card-image"
-        :src="image"
-        :alt="title || alt"
+    <template v-if="titleLink">
+      <a
+        v-if="title"
+        class="card-image-link"
+        :href="titleLink"
+        aria-hidden="true"
         role="presentation"
+        tabindex="-1"
       >
-    </a>
+        <img
+          v-if="image"
+          class="card-image"
+          :src="image"
+          :alt="title"
+          role="presentation"
+        >
+      </a>
+      <a
+        v-else
+        class="card-image-link"
+        :href="titleLink"
+      >
+        <img
+          v-if="image"
+          class="card-image"
+          :src="image"
+          :alt="alt"
+        >
+      </a>
+    </template>
     <span
       v-else
       class="card-image-wrapper"
@@ -62,6 +76,10 @@
 export default {
   props: {
     image: {
+      type: String,
+      default: null
+    },
+    alt: {
       type: String,
       default: null
     },

--- a/src/components/VPerson.vue
+++ b/src/components/VPerson.vue
@@ -1,24 +1,51 @@
 <template>
   <v-card
     class="person-card"
-    :image="person.image"
-    :title="person.name"
-    :title-link="person.nameLink"
-    :subtitle="person.role"
+    :image="image"
+    :title="name"
+    :title-link="nameLink"
+    :subtitle="role"
   />
 </template>
 
 <script>
 import VCard from './VCard'
 
+/**
+ * A component for displaying details about a person
+ */
 export default {
   components: {
     VCard
   },
   props: {
-    person: {
-      type: Object,
-      default () { return {} }
+    /**
+     *  A URL pointing to an image of the person.
+     */
+    image: {
+      type: String,
+      default: null
+    },
+    /**
+     *  Full name of the person.
+     */
+    name: {
+      type: String,
+      default: null
+    },
+    /**
+     *  A URL pointing to the person's bio page.
+     */
+    nameLink: {
+      type: String,
+      default: null
+    },
+    /**
+     *  The person's role or job. e.g. Host, Guest, Author, etc.
+     */
+    role: {
+      type: String,
+      default: null
     }
   }
 }
@@ -26,16 +53,22 @@ export default {
 
 <style lang="scss">
 .person-card {
-  --card-image-width: 72px;
-  --card-image-height: 72px;
-  width: auto;
+  --card-image-width: 112px;
+  --card-image-height: 112px;
+  width: 200px;
+  flex-direction: column;
+  text-align: center;
+  align-items: center;
   background: transparent;
   box-shadow: none;
   border-radius: 0;
   margin: var(space-4);
-    @include media(">medium") {
-    --card-image-width: 112px;
-    --card-image-height: 112px;
+  @include media(">medium") {
+    width: auto;
+    flex-direction: row;
+    text-align: left;
+    --card-image-width: 100px;
+    --card-image-height: 100px;
   }
 }
 
@@ -71,4 +104,17 @@ export default {
     }
   }
 
+  .person-card.mod-horizontal-mobile {
+    width: auto;
+    flex-direction: row;
+    text-align: left;
+  }
+
+  .person-card.mod-vertical-desktop {
+    @include media(">medium") {
+      width: 200px;
+      flex-direction: column;
+      text-align: center;
+    }
+  }
 </style>

--- a/src/tests/VPerson.test.js
+++ b/src/tests/VPerson.test.js
@@ -14,7 +14,7 @@ describe('VPerson', () => {
     const nameLink = 'https://example.com'
     const role = 'Subtitle'
     const wrapper = mount(VPerson, {
-      propsData: { person: { image, name, nameLink, role } }
+      propsData: { image, name, nameLink, role }
     })
     // check if prop works and was rendered correctly
     const img = wrapper.find('.card-image')
@@ -32,7 +32,7 @@ describe('VPerson', () => {
     const nameLink = 'https://example.com'
     const role = 'Subtitle'
     const wrapper = mount(VPerson, {
-      propsData: { person: { image, name, nameLink, role } }
+      propsData: { image, name, nameLink, role }
     })
     const results = await axe(wrapper.element)
     expect(results).toHaveNoViolations()

--- a/stories/90-Components/Molecules/Person.stories.mdx
+++ b/stories/90-Components/Molecules/Person.stories.mdx
@@ -1,47 +1,123 @@
-import { Meta, Canvas, Story } from '@storybook/addon-docs/blocks';
-import VPerson from '../../../src/components/VPerson'
+import { Meta, Canvas, Story, Title, Subtitle, Description, ArgsTable } from '@storybook/addon-docs/blocks';
+import VPerson from '../../../src/components/VPerson';
+const component = VPerson;
 
-<Meta title="Components/Molecules/Person" />
+<Meta title="Components/Molecules/Person" component={component} />
+
+<Title />
+
+## Description
+
+<Description of={component} />
+
+## Component Properties
+
+<ArgsTable of={component} />
+
+## Stories
+
+### Person
 
 <Canvas>
     <Story name="Person">
         {{
             components: { VPerson },
-            data() {
-                return {
-                    person: {
-                        image: 'http://placehold.it/200x200',
-                        name: 'Title',
-                        role: 'Subtitle'
-                    }
-                }
-            },
             template: `
 <v-person
-    :person="person"
+    image='http://placehold.it/200x200'
+    name='Firstname Lastname'
+    role='Host'
 />
 `
         }}
     </Story>
 </Canvas>
 
+### Person With Link
+
 <Canvas>
     <Story name="Person with Link">
         {{
             components: { VPerson },
-            data() {
-                return {
-                    person: {
-                        image: 'http://placehold.it/200x200',
-                        name: 'Title',
-                        nameLink: 'http://example.com',
-                        role: 'Subtitle',
-                    }
-                }
-            },
             template: `
 <v-person
-    :person="person"
+    image='http://placehold.it/200x200'
+    name='Firstname Lastname'
+    nameLink='http://example.com'
+    role='Host'
+/>
+`
+        }}
+    </Story>
+</Canvas>
+
+### Person With No Image
+
+<Canvas>
+    <Story name="Person With No Image">
+        {{
+            components: { VPerson },
+            template: `
+<v-person
+    name="Firstname Lastname"
+    nameLink='http://example.com'
+    role="Host"
+/>
+`
+        }}
+    </Story>
+</Canvas>
+
+### Person With Image Only
+
+
+<Canvas>
+    <Story name="Person With Image Only">
+        {{
+            components: { VPerson },
+            template: `
+<v-person
+    image='http://placehold.it/200x200'
+    alt='Firstname Lastname'
+    nameLink='http://example.com'
+/>
+`
+        }}
+    </Story>
+</Canvas>
+
+### Person Vertical
+
+<Canvas>
+    <Story name="Person Vertical">
+        {{
+            components: { VPerson },
+            template: `
+<v-person
+    class="mod-vertical-desktop"
+    image='http://placehold.it/200x200'
+    name='Firstname Lastname'
+    nameLink='http://example.com'
+    role='Host'
+/>
+`
+        }}
+    </Story>
+</Canvas>
+
+### Person Horizontal (even in mobile)
+
+<Canvas>
+    <Story name="Person Horizontal">
+        {{
+            components: { VPerson },
+            template: `
+<v-person
+    class="mod-horizontal-mobile"
+    image='http://placehold.it/200x200'
+    name='Firstname Lastname'
+    nameLink='http://example.com'
+    role='Host'
 />
 `
         }}


### PR DESCRIPTION
- Update card to handle the image with no title case (image should still click through to title link)
- Refactor person to use individual props instead of an opaque person object for now
- Add more person stories to cover more variations, add titles to stories
- Add JSDoc comments to Person props, storybook can use these to generate a nice props table, see the ArgsTable jsx component in the updated story page. Examples of documenting a Vue component: https://github.com/vue-styleguidist/vue-styleguidist/tree/dev/packages/vue-docgen-api#props
- Add styles to configure vertical horizontal layouts on person card, (default is vertical desktop, horizontal mobile)