### PR TITLE
WNYC-324 Main Player Tweaks

### DIFF
--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -291,6 +291,7 @@ h1, h2, h3, h4, h5 {
 .main-player {
   @extend .wnyc-card-styles;
   margin: auto;
+  position: relative;
 }
 
 .main-player-details-link {
@@ -302,7 +303,7 @@ h1, h2, h3, h4, h5 {
 .main-player .on-air-image {
   max-width: 204px;
   max-height: 204px;
-  margin: 16px auto 24px auto;
+  margin: 64px auto 24px auto;
   @include media('>=medium') {
     max-width: 240px;
     max-height: 240px;
@@ -316,7 +317,21 @@ h1, h2, h3, h4, h5 {
 }
 
 .main-player .live-indicator {
+  position: absolute;
+  margin: 0;
+  top: 24px;
+  left: 50%;
+  -webkit-transform: translateX(-50%);
+  transform: translateX(-50%);
   color: RGB(var(--color-text));
+  @include media('>=medium') {
+    position: static;
+    margin: 0 0 16px 24px;
+    top: auto;
+    left: auto;
+    -webkit-transform: none;
+    transform: none;  
+  }
 }
 
 .main-player .main-player-title {

--- a/src/styles/themes/wnyc/_theme.overrides.scss
+++ b/src/styles/themes/wnyc/_theme.overrides.scss
@@ -299,6 +299,17 @@ h1, h2, h3, h4, h5 {
   padding: 0;
 }
 
+.main-player .on-air-image {
+  max-width: 204px;
+  max-height: 204px;
+  margin: 16px auto 24px auto;
+  @include media('>=medium') {
+    max-width: 240px;
+    max-height: 240px;
+    margin: 45px 16px 45px 40px;
+  }
+}
+
 .main-player .live-indicator .whats-on-live-indicator-text {
   font-size: var(--font-size-4);
   font-weight: 700;


### PR DESCRIPTION
Changes to the WNYC theme's Main Player
- Reduced the main image size and added padding
- Moved the on air indicator section above the main image in mobile view. I believe since this isn't an interactive element, moving the display order out of sync with the source order with CSS should have a minimal impact on screen reader and keyboard nav. I considered using grid to re-order this, but would have to refactor the markup 
 of the player significantly to make that work so I used good old-fashioned absolute positioning instead. 