### PR TITLE
Standardize spelling of gray

### DIFF
--- a/src/components/storybook/GothamistColors.vue
+++ b/src/components/storybook/GothamistColors.vue
@@ -15,8 +15,8 @@
     <div class="u-background-color--dusk-blue">
       <span>dusk-blue</span>
     </div>
-    <div class="u-background-color--brown-grey">
-      <span>brown-grey</span>
+    <div class="u-background-color--brown-gray">
+      <span>brown-gray</span>
     </div>
     <div class="u-background-color--dirty-salmon">
       <span>dirty-salmon</span>
@@ -79,8 +79,8 @@ export default {
   background: RGB(var(--color-dusk-blue));
 }
 
-.u-background-color--brown-grey {
-  background: RGB(var(--color-brown-grey));
+.u-background-color--brown-gray {
+  background: RGB(var(--color-brown-gray));
 }
 
 .u-background-color--dirty-salmon {

--- a/src/styles/themes/gothamist/_theme.colors.scss
+++ b/src/styles/themes/gothamist/_theme.colors.scss
@@ -21,7 +21,7 @@
   --color-banana-yellow:       #{hex2(#ffc400)};
   --color-taxicab-yellow:      #{hex2(#e3d54a)};
   --color-dusk-blue:           #{hex2(#244c84)};
-  --color-brown-grey:          #{hex2(#939393)};
+  --color-brown-gray:          #{hex2(#939393)};
   --color-dirty-salmon:        #{hex2(#f0eeea)};
   --color-purple:              #{hex2(#924db1)};
 }

--- a/src/styles/themes/gothamist/_theme.overrides.scss
+++ b/src/styles/themes/gothamist/_theme.overrides.scss
@@ -15,7 +15,7 @@ p {
 
 pre,
 blockquote {
-  border: 1px solid RGB(var(--color-brown-grey));
+  border: 1px solid RGB(var(--color-brown-gray));
 }
 
 .o-list--numbered li::before {
@@ -1021,6 +1021,10 @@ form .o-button:hover {
 // new vue overrides
 
 // HEADER
+.c-main-header {
+  position: relative;
+}
+
 .c-main-header .c-primary-nav .c-secondary-nav__item .c-secondary-nav__link {
   @include typeface(body, 6);
   font-family: var(--font-family-pragati);

--- a/src/styles/themes/wqxr/overrides/mixins/_buttons.scss
+++ b/src/styles/themes/wqxr/overrides/mixins/_buttons.scss
@@ -217,7 +217,7 @@
   height: 35px;
   max-height: 35px;
   padding: 0;
-  border: 2px solid $light-grey;
+  border: 2px solid $light-gray;
   border-radius: 50%;
   line-height: 30px;
   text-align: center;
@@ -237,7 +237,7 @@
   height: 28px;
   max-height: 35px;
   padding: 0;
-  border: 2px solid $light-grey;
+  border: 2px solid $light-gray;
   border-radius: 50%;
   line-height: 22px;
   text-align: center;

--- a/src/styles/themes/wqxr/overrides/mixins/_text.scss
+++ b/src/styles/themes/wqxr/overrides/mixins/_text.scss
@@ -10,7 +10,7 @@
 }
 
 @mixin text_transparent {
-  color: $dark-grey;
+  color: $dark-gray;
 }
 
 @mixin text_bright-link {
@@ -154,7 +154,7 @@
   font-size: 12px;
   font-weight: 600;
   line-height: 1.67;
-  color: $dark-grey;
+  color: $dark-gray;
   a {
     @include text_dark-link;
   }

--- a/src/styles/themes/wqxr/overrides/vars/_tools.sg-updates.scss
+++ b/src/styles/themes/wqxr/overrides/vars/_tools.sg-updates.scss
@@ -31,7 +31,7 @@ $c-reddish-orange: #de5e36;
 $c-banana-yellow: #ffc400;
 $c-taxicab-yellow: #e3d54a;
 $c-dusk-blue: #244c84;
-$c-brown-grey: #939393;
+$c-brown-gray: #939393;
 $c-dirty-salmon: #f0eeea;
 $c-purple: #924db1;
 $c-denim-blue: #00518e;
@@ -43,7 +43,7 @@ $c-tertiary: $c-WNYC-fireengine-red;
 $c-quaternary: $c-banana-yellow;
 $c-quinary: $c-taxicab-yellow;
 $c-senary: $c-dusk-blue;
-$c-septenary: $c-brown-grey;
+$c-septenary: $c-brown-gray;
 $c-octonary: $c-dirty-salmon;
 $c-nonary: $c-purple;
 

--- a/stories/02-Foundations/23-WQXR Palette.stories.mdx
+++ b/stories/02-Foundations/23-WQXR Palette.stories.mdx
@@ -15,7 +15,7 @@ WQXR COLOR SWATCHES (PRIMARY / UTILITY)
 | Utility | COLOR SWATCHES HERE |
 
 
-**Denim Blue** is the primary color for CTAs, secondary headers, and may be used as a background color or for larger, prominent elements. **Water Blue** can be used as a background color or as a tertiary header color. **Azure** is purely a decorative lighter alternative. **White** is the primary color for headers, footer text, tooltip text, logos, and buttons. **Black** is used for main text on white card backgrounds and as the tooltip background color. **Grey Dark** may be used for main headers on editorial pages. **White 50 opacity** may be used for smaller headers on blue backgrounds. **Black 50 opacity** may be used for time information on playlists.
+**Denim Blue** is the primary color for CTAs, secondary headers, and may be used as a background color or for larger, prominent elements. **Water Blue** can be used as a background color or as a tertiary header color. **Azure** is purely a decorative lighter alternative. **White** is the primary color for headers, footer text, tooltip text, logos, and buttons. **Black** is used for main text on white card backgrounds and as the tooltip background color. **gray Dark** may be used for main headers on editorial pages. **White 50 opacity** may be used for smaller headers on blue backgrounds. **Black 50 opacity** may be used for time information on playlists.
 
 
 ### Color Groups


### PR DESCRIPTION
This caused a few theme color vars to be undefined because they were using 'gray' with an 'a' where the base color they were trying to point to wasn't