### PR TITLE
remove overflow hack from html element

### DIFF
--- a/src/styles/_library/_base.main.scss
+++ b/src/styles/_library/_base.main.scss
@@ -1,10 +1,6 @@
 /*------------------------------------*\
     $SITE MAIN
 \*------------------------------------*/
-html {
-  overflow-y: scroll;
-}
-
 body {
   background: RGB(var(--color-background));
   @include typeface(body, 5);


### PR DESCRIPTION
I'm pretty sure the reason this rule is here, is to force some browsers to always show a vertical scrollbar so that the viewport width doesn't change when you navigate to a page that's shorter than the viewport height and has no scrollbar... I'm not too worried about this and i'm sure there are other workarounds for that edge case. 

Right now, this is causing issues with using native `position: sticky` which i'm using for dealing with the header and ad banner above the header. So I'm taking it out.