### PR TITLE
Fix article color vars in the gothamist theme

### DIFF
--- a/src/styles/_library/_module.article.scss
+++ b/src/styles/_library/_module.article.scss
@@ -22,19 +22,19 @@
   text-decoration: var(--text-decoration-link);
   text-underline-position: under;
   border-bottom: none;
-  color: (var(--color-link));
+  color: RGB(var(--color-link));
 
   &:hover {
     text-decoration: var(--text-decoration-link-hover);
-    color: (var(--color-link-hover));
+    color: RGB(var(--color-link-hover));
   }
 }
 
 .c-article__header .u-has-accent--secondary {
-  color: (var(--color-link));
+  color: RGB(var(--color-link));
 
   &:hover {
-    color: (var(--color-link-hover));
+    color: RGB(var(--color-link-hover));
   }
 }
 
@@ -53,7 +53,7 @@
 }
 
 .c-article__meta .o-byline a {
-  color: (var(--color-text));
+  color: RGB(var(--color-text));
 }
 
 .c-article__meta-group > * {


### PR DESCRIPTION
This fixes the link colors in the article body