### PR TITLE
Mwalsh/goth 246 font optimization

### DIFF
--- a/src/styles/themes/gothamist/_theme.fonts.scss
+++ b/src/styles/themes/gothamist/_theme.fonts.scss
@@ -5,4 +5,66 @@
 // https://fonts.google.com/specimen/Pragati+Narrow
 // https://fonts.google.com/specimen/B612+Mono
 // https://fonts.google.com/specimen/Barlow
-@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:700|B612+Mono:400|Barlow:400&display=optional');
+/* latin */
+@font-face {
+    font-family: 'B612 Mono';
+    font-style: normal;
+    font-weight: 400;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/b612mono/v5/kmK_Zq85QVWbN1eW6lJV0A7diOdDtw.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 400;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/barlow/v5/7cHpv4kjgoGqM7E_Ass5ynghnQci.woff2) format('woff2');
+    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 400;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/barlow/v5/7cHpv4kjgoGqM7E_DMs5ynghnQ.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 700;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/barlow/v5/7cHqv4kjgoGqM7E3t-4s6Vostz0rdom9.woff2) format('woff2');
+    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Barlow';
+    font-style: normal;
+    font-weight: 700;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/barlow/v5/7cHqv4kjgoGqM7E3t-4s51ostz0rdg.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }
+  /* latin-ext */
+  @font-face {
+    font-family: 'Pragati Narrow';
+    font-style: normal;
+    font-weight: 700;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/pragatinarrow/v8/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5cd2EpIxlZ_5MSs.woff2) format('woff2');
+    unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  }
+  /* latin */
+  @font-face {
+    font-family: 'Pragati Narrow';
+    font-style: normal;
+    font-weight: 700;
+    font-display: optional;
+    src: url(https://fonts.gstatic.com/s/pragatinarrow/v8/vm8sdRf0T0bS1ffgsPB7WZ-mD2ZD5cd4EpIxlZ_5.woff2) format('woff2');
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  }

--- a/src/styles/themes/gothamist/_theme.fonts.scss
+++ b/src/styles/themes/gothamist/_theme.fonts.scss
@@ -5,4 +5,4 @@
 // https://fonts.google.com/specimen/Pragati+Narrow
 // https://fonts.google.com/specimen/B612+Mono
 // https://fonts.google.com/specimen/Barlow
-@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:400|B612+Mono:400|Barlow:400&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:700|B612+Mono:400|Barlow:400&display=swap');

--- a/src/styles/themes/gothamist/_theme.fonts.scss
+++ b/src/styles/themes/gothamist/_theme.fonts.scss
@@ -5,4 +5,4 @@
 // https://fonts.google.com/specimen/Pragati+Narrow
 // https://fonts.google.com/specimen/B612+Mono
 // https://fonts.google.com/specimen/Barlow
-@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:400,700|B612+Mono:400,700|Barlow:400,400i,700,700i&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:400|B612+Mono:400|Barlow:400&display=swap');

--- a/src/styles/themes/gothamist/_theme.fonts.scss
+++ b/src/styles/themes/gothamist/_theme.fonts.scss
@@ -5,4 +5,4 @@
 // https://fonts.google.com/specimen/Pragati+Narrow
 // https://fonts.google.com/specimen/B612+Mono
 // https://fonts.google.com/specimen/Barlow
-@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:700|B612+Mono:400|Barlow:400&display=swap');
+@import url('https://fonts.googleapis.com/css?family=Pragati+Narrow:700|B612+Mono:400|Barlow:400&display=optional');


### PR DESCRIPTION
This PR is just an example.

### Things we probably want to do
- **Reduce number of font faces (This will require design work**)

I think ideally we can probably get away with without losing too much appearance-wise:

Heading: bold only (big downside here is we can't do faux non-bold)
Body: normal and bold
Small: normal only

Right now there are a few places that would need design attention, especially the header.
Buttons use the bold version of the small font, the header menu uses the non-bold version of the heading font, etc. We might want to play with the letter spacing etc., to make these look better.

- **Self hosting the font import CSS code, maybe the fonts**

Right now Google Fonts are loaded via importing a CSS file from Google's server which then points to the actual font files. We could save a step by including this in our CSS bundle, or even better, inlined in the html itself.

We might also want to consider hosting the fonts themselves, although I don't know how much difference we'll actually see between loading from google or loading from S3. I'd put this off until later. I'm not 100% sure how long we can trust Google's fingerprinted font urls to stay alive, but it's probably fine to use them. We'll see.

### Optional things that will require a little more effort to get right
**Using `display: optional`**
- **Set intentional fallback (This will require design work)**
If we set display option there's a good chance many visitors will see the fallback fonts. We want a fallback or fallbacks that will cover all major platforms (e.g. iOS, Android, Windows, OSX). We should expect these to be seen at least some of the time and test the design with the fallback fonts to make sure the appearance is still acceptable. For example, right now the only fallback for the the header is Helvetica and not all systems have Helvetica. We may also need to tweak some components, for example the header menu, to make sure they can handle wider or narrower text gracefully.

**OR**
- **Use font mods to adjust the fallback fonts' sizes**
If we don't use display optional, we can still reduce the impact of CLS.
When we define our fallback fonts we can use a combination of the `descent-override`, `ascent-override`, and `size-adjust` properties to make the fallback fonts match our webfonts more closely. This will mitigate but not eliminate CLS. This is not perfect and it's very fiddly to get the numbers right but it can still make a big difference.