### PR TITLE
Bono/goth 267

### DIFF
--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -12,54 +12,53 @@
     >
       <search-icon />
     </v-button>
-    <transition :name="transition">
-      <div
-        :style="searchIsOpen ? '' : 'display:none;' "
-        class="search-bar-form-wrapper"
+    <div
+      :style="searchIsOpen ? '' : 'display:none;' "
+      class="search-bar-form-wrapper"
+    >
+      <form
+        ref="searchForm"
+        class="search-bar-form"
+        aria-hidden="true"
+        role="search"
+        :action="action"
+        method="get"
       >
-        <form
-          ref="searchForm"
-          class="search-bar-form"
-          aria-hidden="true"
-          role="search"
-          :action="action"
-          method="get"
+        <label
+          for="search"
+          class="is-vishidden"
         >
-          <label
-            for="search"
-            class="is-vishidden"
-          >
-            {{ placeholder }}
-          </label>
-          <v-button
-            v-if="showCloseIcon"
-            class="search-bar-close"
-            tabindex="0"
-            @click="close"
-            @keypress.enter.space.prevent="close"
-          >
-            <close-icon />
-          </v-button>
-          <input
-            ref="searchInput"
-            v-model="search"
-            name="q"
-            :placeholder="placeholder"
-            class="search-bar-input"
-            type="search"
-            @keypress="listenToInput"
-          >
-          <v-button
-            class="search-bar-submit"
-            tabindex="0"
-            @click.native="submit"
-            @keypress.enter.space.prevent="submit"
-          >
-            <search-icon />
-          </v-button>
-        </form>
-      </div>
-    </transition>
+          {{ placeholder }}
+        </label>
+        <v-button
+          v-if="showCloseIcon"
+          class="search-bar-close"
+          tabindex="0"
+          @click="close"
+          @keypress.enter.space.prevent="close"
+        >
+          <close-icon />
+        </v-button>
+        <input
+          ref="searchInput"
+          v-model="search"
+          name="q"
+          :placeholder="placeholder"
+          class="search-bar-input"
+          type="search"
+          @keypress="listenToInput"
+        >
+        <v-button
+          class="search-bar-submit"
+          tabindex="0"
+          @click.native="submit"
+          @keypress.enter.space.prevent="submit"
+        >
+          <search-icon />
+        </v-button>
+      </form>
+    </div>
+    
   </div>
 </template>
 

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -118,6 +118,7 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
+      console.log('listenToInput')
       // close the search bar if nothing is typed for 3 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {
@@ -126,10 +127,12 @@ export default {
       }, 6000)
     },
     open (e) {
+      console.log('open')
       this.$emit('searchBarOpen', e)
       this.searchIsOpen = true
       this.$nextTick(() => {
-        this.$refs.searchInput.focus()
+        console.log('next tick')
+        this.$refs.searchInput.focus({ preventScroll: false })
         this.listenToInput()
       })
     },

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -41,13 +41,13 @@
             <close-icon />
           </v-button>
           <input
-            id="search"
             ref="searchInput"
             v-model="search"
             name="q"
             :placeholder="placeholder"
             class="search-bar-input"
             type="search"
+            @keypress="listenToInput"
           >
           <v-button
             class="search-bar-submit"
@@ -116,22 +116,22 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
-      console.log('listenToInput empty')
-      // // close the search bar if nothing is typed for 3 seconds
-      // if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
-      // this.timeoutHandler = setTimeout(() => {
-      //   this.close()
-      //   clearTimeout(this.timeoutHandler)
-      // }, 6000)
+      console.log('listenToInput')
+      // close the search bar if nothing is typed for 6 seconds
+      if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
+      this.timeoutHandler = setTimeout(() => {
+        this.close()
+        clearTimeout(this.timeoutHandler)
+      }, 6000)
     },
     open (e) {
       console.log('open')
-      // this.$emit('searchBarOpen', e)
+      this.$emit('searchBarOpen', e)
       this.searchIsOpen = true
       this.$nextTick(() => {
-      //   console.log('next tick')
+        console.log('next tick')
         this.$refs.searchInput.focus({ preventScroll: true })
-      // this.listenToInput()
+        this.listenToInput()
       })
     },
     submit (e) {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -130,11 +130,11 @@ export default {
       console.log('open')
       // this.$emit('searchBarOpen', e)
       this.searchIsOpen = true
-      // this.$nextTick(() => {
+      this.$nextTick(() => {
       //   console.log('next tick')
-      this.$refs.searchInput.focus({ preventScroll: false })
+        this.$refs.searchInput.focus({ preventScroll: false })
       // this.listenToInput()
-      // })
+      })
     },
     submit (e) {
       this.$emit('searchBarSubmit', e)

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -132,8 +132,8 @@ export default {
       this.searchIsOpen = true
       // this.$nextTick(() => {
       //   console.log('next tick')
-      //   this.$refs.searchInput.focus({ preventScroll: false })
-      //   this.listenToInput()
+      this.$refs.searchInput.focus({ preventScroll: false })
+      // this.listenToInput()
       // })
     },
     submit (e) {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -116,6 +116,11 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
+      // keep current scroll position
+      const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
+      this.$nextTick(() => {
+        window.scrollTo(0, scrollTop)
+      })
       // close the search bar if nothing is typed for 6 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -118,23 +118,23 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
-      console.log('listenToInput')
-      // close the search bar if nothing is typed for 3 seconds
-      if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
-      this.timeoutHandler = setTimeout(() => {
-        this.close()
-        clearTimeout(this.timeoutHandler)
-      }, 6000)
+      console.log('listenToInput empty')
+      // // close the search bar if nothing is typed for 3 seconds
+      // if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
+      // this.timeoutHandler = setTimeout(() => {
+      //   this.close()
+      //   clearTimeout(this.timeoutHandler)
+      // }, 6000)
     },
     open (e) {
       console.log('open')
-      this.$emit('searchBarOpen', e)
+      // this.$emit('searchBarOpen', e)
       this.searchIsOpen = true
-      this.$nextTick(() => {
-        console.log('next tick')
-        this.$refs.searchInput.focus({ preventScroll: false })
-        this.listenToInput()
-      })
+      // this.$nextTick(() => {
+      //   console.log('next tick')
+      //   this.$refs.searchInput.focus({ preventScroll: false })
+      //   this.listenToInput()
+      // })
     },
     submit (e) {
       this.$emit('searchBarSubmit', e)

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -116,6 +116,9 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
+      // keep current scroll position
+      const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
+      window.scrollTo(0, scrollTop)
       // close the search bar if nothing is typed for 6 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -24,7 +24,6 @@
           role="search"
           :action="action"
           method="get"
-          @keypress="listenToInput"
         >
           <label
             for="search"
@@ -49,7 +48,6 @@
             :placeholder="placeholder"
             class="search-bar-input"
             type="search"
-            @keypress="listenToInput"
           >
           <v-button
             class="search-bar-submit"
@@ -132,7 +130,7 @@ export default {
       this.searchIsOpen = true
       this.$nextTick(() => {
       //   console.log('next tick')
-        this.$refs.searchInput.focus({ preventScroll: false })
+        this.$refs.searchInput.focus({ preventScroll: true })
       // this.listenToInput()
       })
     },

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -114,6 +114,7 @@ export default {
     close (e) {
       this.$emit('searchBarClose', e)
       this.searchIsOpen = false
+      this.clearSearch()
     },
     listenToInput () {
       // close the search bar if nothing is typed for 6 seconds
@@ -130,6 +131,9 @@ export default {
         this.$refs.searchInput.focus({ preventScroll: true })
         this.listenToInput()
       })
+    },
+    clearSearch () {
+      this.search = ''
     },
     submit (e) {
       this.$emit('searchBarSubmit', e)

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -12,53 +12,48 @@
     >
       <search-icon />
     </v-button>
-    <div
-      :style="searchIsOpen ? '' : 'display:none;' "
-      class="search-bar-form-wrapper"
-    >
-      <form
-        ref="searchForm"
-        class="search-bar-form"
-        aria-hidden="true"
-        role="search"
-        :action="action"
-        method="get"
+    <transition :name="transition">
+      <div
+        :style="searchIsOpen ? '' : 'display:none;' "
+        class="search-bar-form-wrapper"
       >
-        <label
-          for="search"
-          class="is-vishidden"
+        <form
+          ref="searchForm"
+          class="search-bar-form"
+          aria-hidden="true"
+          role="search"
+          :action="action"
+          method="get"
         >
-          {{ placeholder }}
-        </label>
-        <v-button
-          v-if="showCloseIcon"
-          class="search-bar-close"
-          tabindex="0"
-          @click="close"
-          @keypress.enter.space.prevent="close"
-        >
-          <close-icon />
-        </v-button>
-        <input
-          ref="searchInput"
-          v-model="search"
-          name="q"
-          :placeholder="placeholder"
-          class="search-bar-input"
-          type="search"
-          @keypress="listenToInput"
-        >
-        <v-button
-          class="search-bar-submit"
-          tabindex="0"
-          @click.native="submit"
-          @keypress.enter.space.prevent="submit"
-        >
-          <search-icon />
-        </v-button>
-      </form>
-    </div>
-    
+          <label
+            for="search"
+            class="is-vishidden"
+          >
+            {{ placeholder }}
+          </label>
+          <v-button
+            v-if="showCloseIcon"
+            class="search-bar-close"
+            tabindex="0"
+            @click="close"
+            @keypress.enter.space.prevent="close"
+          >
+            <close-icon />
+          </v-button>
+          <input
+            ref="searchInput"            
+          >
+          <v-button
+            class="search-bar-submit"
+            tabindex="0"
+            @click.native="submit"
+            @keypress.enter.space.prevent="submit"
+          >
+            <search-icon />
+          </v-button>
+        </form>
+      </div>
+    </transition>
   </div>
 </template>
 

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -41,7 +41,13 @@
             <close-icon />
           </v-button>
           <input
-            ref="searchInput"            
+            ref="searchInput"
+            v-model="search"
+            name="q"
+            :placeholder="placeholder"
+            class="search-bar-input"
+            type="search"
+            @keypress="listenToInput"
           >
           <v-button
             class="search-bar-submit"
@@ -110,7 +116,6 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
-      console.log('listenToInput')
       // close the search bar if nothing is typed for 6 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {
@@ -119,11 +124,9 @@ export default {
       }, 6000)
     },
     open (e) {
-      console.log('open')
       this.$emit('searchBarOpen', e)
       this.searchIsOpen = true
       this.$nextTick(() => {
-        console.log('next tick')
         this.$refs.searchInput.focus({ preventScroll: true })
         this.listenToInput()
       })
@@ -165,6 +168,7 @@ export default {
   position: absolute;
   z-index: 2;
   display: flex;
+  top: 3px;
 }
 
 .search-bar .search-bar-form-wrapper .search-bar-donate {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -116,9 +116,6 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
-      // keep current scroll position
-      const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
-      window.scrollTo(0, scrollTop)
       // close the search bar if nothing is typed for 6 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -116,11 +116,6 @@ export default {
       this.searchIsOpen = false
     },
     listenToInput () {
-      // keep current scroll position
-      const scrollTop = document.documentElement.scrollTop || document.body.scrollTop
-      this.$nextTick(() => {
-        window.scrollTo(0, scrollTop)
-      })
       // close the search bar if nothing is typed for 6 seconds
       if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {

--- a/src/components/VSearch.vue
+++ b/src/components/VSearch.vue
@@ -77,7 +77,6 @@ export default {
     SearchIcon,
     VButton
   },
-  emits: ['searchBarOpen', 'searchBarClose', 'searchBarSubmit'],
   props: {
     action: {
       type: String,
@@ -100,6 +99,7 @@ export default {
       default: 'slide-right'
     }
   },
+  emits: ['searchBarOpen', 'searchBarClose', 'searchBarSubmit'],
   data () {
     return {
       searchIsOpen: true,
@@ -119,10 +119,10 @@ export default {
     },
     listenToInput () {
       // close the search bar if nothing is typed for 3 seconds
-      window.clearTimeout(this.timeoutHandler)
+      if (this.timeoutHandler) { clearTimeout(this.timeoutHandler) }
       this.timeoutHandler = setTimeout(() => {
         this.close()
-        window.clearTimeout(this.timeoutHandler)
+        clearTimeout(this.timeoutHandler)
       }, 6000)
     },
     open (e) {

--- a/src/styles/themes/gothamist/_theme.overrides.scss
+++ b/src/styles/themes/gothamist/_theme.overrides.scss
@@ -1462,7 +1462,7 @@ ul.o-rte-text li li:before,
   background: none !important;
   position: absolute;
   right: 0;
-  top: 4px;
+  top: 2px;
 
   &:hover {
     background: none !important;

--- a/src/styles/themes/gothamist/_theme.overrides.scss
+++ b/src/styles/themes/gothamist/_theme.overrides.scss
@@ -1402,9 +1402,7 @@ ul.o-rte-text li li:before,
 
 // search bar
 .c-main-header .header-search-bar {
-  position: fixed;
-  right: 10px;
-  top: 10px;
+  margin: 0 !important;
 }
 
 .menu .search-bar {
@@ -1424,7 +1422,7 @@ ul.o-rte-text li li:before,
   background: none !important;
   position: absolute;
   right: 0;
-  top: 4px;
+  top: 2px;
 
   &:hover {
     background: none !important;

--- a/src/styles/themes/gothamist/_theme.overrides.scss
+++ b/src/styles/themes/gothamist/_theme.overrides.scss
@@ -1402,9 +1402,9 @@ ul.o-rte-text li li:before,
 
 // search bar
 .c-main-header .header-search-bar {
-  position: absolute;
-  right: 0;
-  top: 2px;
+  position: fixed;
+  right: 10px;
+  top: 10px;
 }
 
 .menu .search-bar {

--- a/stories/90-Components/Molecules/Search.stories.js
+++ b/stories/90-Components/Molecules/Search.stories.js
@@ -9,7 +9,54 @@ export const Default = () => ({
     VSearch
   },
   template: `
-    <v-search action="http://www.google.com" />
+    <v-search  closed-on-load
+      show-close-icon action="http://www.google.com" />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
+      <br />
   `
 })
 

--- a/stories/90-Components/Molecules/Search.stories.js
+++ b/stories/90-Components/Molecules/Search.stories.js
@@ -9,54 +9,7 @@ export const Default = () => ({
     VSearch
   },
   template: `
-    <v-search  closed-on-load
-      show-close-icon action="http://www.google.com" />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
-      <br />
+    <v-search action="http://www.google.com" />
   `
 })
 


### PR DESCRIPTION
this description is the same on the GOTH PR:

This one is a tricky one. I will need to explain over a zoom call. 
But in a nut shell. html { scroll-padding-top: 85px; } is the issue in the default.vue and a small update in the component. 

In the DS,  VSearch.vue, I just updated the focus() to this: "this.$refs.searchInput.focus({ preventScroll: true })". This stopped the scrolling when initially clicking on the search icon and getting focus on the text field.


The reason tying in the text field scrolls the site is because it is trying to get the text field into the view port, which is currently set to be 85px ( html { scroll-padding-top: 85px; } ) from the top. But because the text field in in the sticky header, it never reaches the specified viewport. To prevent this, you have to make something around the search input to be position:fixed. So, I added the following in GothamistHeaader.vue:

.gothamist-header.is-stuck .c-main-header__right .search-bar-form-wrapper {
  position: fixed;
  top: 12px;
  right: 16px !important;
}

This css makes the search bar position fixed with the ".is-stuck" is added by the "v-observe-visibility". It works well, except for one small instance on the home page... when .is-stuck is applied a little early, and the search field is not positioned properly. Maybe you (kim) can explain more on how the "v-observe-visibility" is working better, and maybe I can resolve that small issue.
