### PR TITLE
Add custom link component to vcard

### DIFF
--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -16,7 +16,12 @@
 import RouteLocationRaw from 'vue-router'
 export default {
   name: 'FlexibleLink',
-  props: { to: RouteLocationRaw },
+  props: {
+    to: {
+      type: RouteLocationRaw,
+      required: false
+    }
+  },
   computed: {
     isExternal () {
       if (typeof this.to === 'string' && /^http(s)+:/.test(this.to)) {

--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -1,0 +1,27 @@
+<template>
+  <a v-if="isExternal" 
+    v-bind="{...$props, ...$attrs}"
+    :href="to" 
+    target="_blank" 
+    rel="noopener noreferrer"> 
+    <slot name="default"></slot>
+  </a>
+  <nuxt-link v-else v-bind="{...$props, ...$attrs}">
+    <slot name="default"></slot>
+  </nuxt-link>
+</template>
+
+<script>
+export default {
+  name: 'FlexibleLink',
+  props: ['to'],
+  computed: {
+    isExternal () {
+      if (/^http(s)+:/.test(this.to)) {
+        return true
+      }
+      return false
+    }
+  }
+}
+</script>

--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -3,7 +3,8 @@
     v-bind="{...$props, ...$attrs}"
     :href="to" 
     target="_blank" 
-    rel="noopener noreferrer"> 
+    rel="noopener noreferrer"
+    class="external">
     <slot name="default"></slot>
   </a>
   <nuxt-link v-else v-bind="{...$props, ...$attrs}">

--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -19,7 +19,7 @@ export default {
   props: {
     to: {
       type: RouteLocationRaw,
-      required: false
+      default: ''
     }
   },
   computed: {

--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -12,12 +12,13 @@
 </template>
 
 <script>
+import RouteLocationRaw from 'vue-router'
 export default {
   name: 'FlexibleLink',
-  props: ['to'],
+  props: { to: RouteLocationRaw },
   computed: {
     isExternal () {
-      if (/^http(s)+:/.test(this.to)) {
+      if (typeof this.to === 'string' && /^http(s)+:/.test(this.to)) {
         return true
       }
       return false

--- a/src/components/VCard.vue
+++ b/src/components/VCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card">
     <template v-if="titleLink">
-      <nuxt-link
+      <flexible-link
         v-if="title"
         class="card-image-link card-image-wrapper"
         :to="titleLink"
@@ -21,8 +21,8 @@
           :alt="title"
           role="presentation"
         />
-      </nuxt-link>
-      <nuxt-link
+      </flexible-link>
+      <flexible-link
         v-else
         class="card-image-link"
         :to="titleLink"
@@ -38,7 +38,7 @@
           :max-width="imageMaxWidth || Infinity"
           :max-height="imageMaxHeight || Infinity"
         />
-      </nuxt-link>
+      </flexible-link>
     </template>
     <span v-else class="card-image-wrapper">
       <simple-responsive-image
@@ -69,7 +69,7 @@
         role="heading"
         aria-level="3"
       >
-        <nuxt-link
+        <flexible-link
           v-if="titleLink"
           class="card-title-link"
           :to="titleLink"
@@ -77,7 +77,7 @@
           <!-- eslint-disable-next-line -->
           <span v-html="title" />
           <gallery-icon v-if="showGalleryIcon" />
-        </nuxt-link>
+        </flexible-link>
         <template v-else>
           <!-- eslint-disable-next-line -->
           <span v-html="title" />
@@ -98,13 +98,15 @@
 import VTag from '../components/VTag'
 import SimpleResponsiveImage from '../components/SimpleResponsiveImage'
 import GalleryIcon from '../components/icons/GalleryIcon'
+import FlexibleLink from '../components/FlexibleLink'
 
 export default {
   name: 'VCard',
   components: {
     GalleryIcon,
     SimpleResponsiveImage,
-    VTag
+    VTag,
+    FlexibleLink
   },
   props: {
     alt: {
@@ -166,6 +168,9 @@ export default {
   computed: {
     hasDetails () {
       return !!this.title || !!this.subtitle || !!this.$slots.default
+    },
+    hasExternalLink () {
+      return this.titleLink && /^http(s)?:/.test(this.titleLink)
     }
   }
 }

--- a/src/tests/FlexibleLink.test.js
+++ b/src/tests/FlexibleLink.test.js
@@ -1,0 +1,53 @@
+import { shallowMount } from '@vue/test-utils'
+import { describe, test, expect, jest } from '@jest/globals'
+import FlexibleLink from '../components/FlexibleLink'
+
+describe('FlexibleLink', () => {
+  let wrapper = {};
+  
+  // find NuxtLink 
+  const findNuxtLink = () => wrapper.find('nuxt-link-stub')
+  // find an 'a' tag
+  const findAnchor = () => wrapper.find('a')
+
+  //component factory
+  const createComponent = ({ propsData = {} } = {}) => {
+    wrapper = shallowMount(FlexibleLink, {
+      propsData,
+      global: {
+        stubs: {
+          'nuxt-link': true
+        }
+      }
+    })
+  }
+
+  afterEach(() => {
+    if (wrapper.destroy) {
+      wrapper.destroy()
+    } else {
+      wrapper = null;
+    }
+  })
+
+  it('should render with a relative link', () => {
+    createComponent({ propsData: {
+      to: '/abc' 
+    }})
+    expect(findNuxtLink().exists()).toBe(true)
+    expect(findNuxtLink().attributes('to')).toBe('/abc')
+  })
+
+
+  it('should render with an external link', () => {
+    createComponent({ propsData:{
+      to: 'https://example.com' 
+    }})
+    expect(findAnchor().exists()).toBe(true)
+    expect(findAnchor().attributes('href')).toBe('https://example.com')
+    expect(findAnchor().attributes('target')).toBe('_blank')
+    expect(findAnchor().attributes('rel')).toBe('noopener noreferrer')
+    expect(findAnchor().attributes('class')).toBe('external')
+  })
+
+})

--- a/src/tests/FlexibleLink.test.js
+++ b/src/tests/FlexibleLink.test.js
@@ -1,5 +1,5 @@
 import { shallowMount } from '@vue/test-utils'
-import { describe, test, expect, jest } from '@jest/globals'
+import { describe, expect } from '@jest/globals'
 import FlexibleLink from '../components/FlexibleLink'
 
 describe('FlexibleLink', () => {


### PR DESCRIPTION
Add support for external links on cards.
Just assumes something that looks like a full absolute url instead of a nuxt route in the to field is an external link.
Only supports 'http' and 'https' for now (do we even want to support plain http?), could also be extended to support 'email:' links too i guess.