### PR TITLE
fix flexiblelink 'to' type weird import, linter cleanup

### DIFF
--- a/src/components/FlexibleLink.vue
+++ b/src/components/FlexibleLink.vue
@@ -1,24 +1,25 @@
 <template>
-  <a v-if="isExternal" 
+  <a
+    v-if="isExternal"
     v-bind="{...$props, ...$attrs}"
-    :href="to" 
-    target="_blank" 
+    :href="to"
+    target="_blank"
     rel="noopener noreferrer"
-    class="external">
-    <slot name="default"></slot>
+    class="external"
+  >
+    <slot name="default" />
   </a>
   <nuxt-link v-else v-bind="{...$props, ...$attrs}">
-    <slot name="default"></slot>
+    <slot name="default" />
   </nuxt-link>
 </template>
 
 <script>
-import RouteLocationRaw from 'vue-router'
 export default {
   name: 'FlexibleLink',
   props: {
     to: {
-      type: RouteLocationRaw,
+      type: [String, Object],
       default: ''
     }
   },

--- a/src/tests/FlexibleLink.test.js
+++ b/src/tests/FlexibleLink.test.js
@@ -3,17 +3,17 @@ import { describe, expect } from '@jest/globals'
 import FlexibleLink from '../components/FlexibleLink'
 
 describe('FlexibleLink', () => {
-  let wrapper = {};
-  
-  // find NuxtLink 
+  let wrapper = {}
+
+  // find NuxtLink
   const findNuxtLink = () => wrapper.find('nuxt-link-stub')
   // find an 'a' tag
   const findAnchor = () => wrapper.find('a')
 
-  //component factory
-  const createComponent = ({ propsData = {} } = {}) => {
+  // component factory
+  const createComponent = ({ props = {} } = {}) => {
     wrapper = shallowMount(FlexibleLink, {
-      propsData,
+      props,
       global: {
         stubs: {
           'nuxt-link': true
@@ -23,31 +23,29 @@ describe('FlexibleLink', () => {
   }
 
   afterEach(() => {
-    if (wrapper.destroy) {
-      wrapper.destroy()
-    } else {
-      wrapper = null;
-    }
+    wrapper.unmount()
   })
 
   it('should render with a relative link', () => {
-    createComponent({ propsData: {
-      to: '/abc' 
-    }})
+    createComponent({
+      props: {
+        to: '/abc'
+      }
+    })
     expect(findNuxtLink().exists()).toBe(true)
     expect(findNuxtLink().attributes('to')).toBe('/abc')
   })
 
-
   it('should render with an external link', () => {
-    createComponent({ propsData:{
-      to: 'https://example.com' 
-    }})
+    createComponent({
+      props: {
+        to: 'https://example.com'
+      }
+    })
     expect(findAnchor().exists()).toBe(true)
     expect(findAnchor().attributes('href')).toBe('https://example.com')
     expect(findAnchor().attributes('target')).toBe('_blank')
     expect(findAnchor().attributes('rel')).toBe('noopener noreferrer')
     expect(findAnchor().attributes('class')).toBe('external')
   })
-
 })


### PR DESCRIPTION
- fixed a just wrong thing i was doing for the router 'to' type definition
- updated tests more after reading the test-utils migration guide https://test-utils.vuejs.org/migration/
- some general linter cleanup stuff